### PR TITLE
Fix conditional check when creating OpenAI client

### DIFF
--- a/jobs_tasks_llm_comparator.py
+++ b/jobs_tasks_llm_comparator.py
@@ -315,7 +315,7 @@ for i in openai_llms_list :
     
     print(f"LLM Running now : {i['name']}")
     
-    if i['api_key'] is None:
+    if i['base_url'] is None:
         client = OpenAI(api_key=i['api_key'])
     else:
         client = OpenAI(api_key=i['api_key'], base_url=i['base_url'])


### PR DESCRIPTION
## Summary
- correct the condition that determines whether a custom base URL is used when instantiating the OpenAI client

## Testing
- `python -m py_compile jobs_tasks_llm_comparator.py`

------
https://chatgpt.com/codex/tasks/task_e_684626ea54c48323bdcc123b6b919e56